### PR TITLE
Lb force fix (#1099)

### DIFF
--- a/doc/tutorials/python/04-lattice_boltzmann/scripts/lb_stokes_force.py
+++ b/doc/tutorials/python/04-lattice_boltzmann/scripts/lb_stokes_force.py
@@ -76,7 +76,7 @@ for i in range(40):
 print("\nIntegration finished.")
 
 # get force that is exerted on the sphere
-force = sphere.get_params()["force"]
+force = sphere.get_force()
 print("Measured force: f=%f" %size(force))
 
 stokes_force = 6*np.pi*kinematic_visc*radius*size(v)

--- a/src/core/lbboundaries/LBBoundary.hpp
+++ b/src/core/lbboundaries/LBBoundary.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "config.hpp"
 #include "shapes/NoWhere.hpp"
 #include "shapes/Shape.hpp"
 #include "Vector.hpp"

--- a/src/python/espressomd/lbboundaries.py
+++ b/src/python/espressomd/lbboundaries.py
@@ -25,3 +25,4 @@ if any(i in espressomd.code_info.features() for i in ["LB_BOUNDARIES", "LB_BOUND
 
     class LBBoundary(ScriptInterfaceHelper):
         _so_name = "LBBoundaries::LBBoundary"
+        _so_bind_methods = ("get_force",)

--- a/src/script_interface/lbboundaries/LBBoundary.hpp
+++ b/src/script_interface/lbboundaries/LBBoundary.hpp
@@ -12,7 +12,6 @@ class LBBoundary : public AutoParameters {
 public:
   LBBoundary() : m_lbboundary(new ::LBBoundaries::LBBoundary()) {
     add_parameters({{"velocity", m_lbboundary->velocity()},
-                    {"force", m_lbboundary->get_force()},
                     {"shape",
                      [this](Variant const &value) {
                        m_shape =
@@ -26,19 +25,26 @@ public:
                        return (m_shape != nullptr) ? m_shape->id() : ObjectId();
                      }}});
 #ifdef EK_BOUNDARIES
-    add_parameters({
-        {"charge_density",
-         [this](Variant const &value) {
-           m_lbboundary->set_charge_density(boost::get<double>(value));
-         },
-         [this]() { return m_lbboundary->charge_density(); }},
-        {"net_charge",
-         [this](Variant const &value) {
-           m_lbboundary->set_net_charge(boost::get<double>(value));
-         },
-         [this]() { return m_lbboundary->net_charge(); }},
-    });
+    add_parameters(
+        {{"charge_density",
+          [this](Variant const &value) {
+            m_lbboundary->set_charge_density(boost::get<double>(value));
+          },
+          [this]() { return m_lbboundary->charge_density(); },
+          VariantType::DOUBLE, 0},
+         {"net_charge",
+          [this](Variant const &value) {
+            m_lbboundary->set_net_charge(boost::get<double>(value));
+          },
+          [this]() { return m_lbboundary->net_charge(); }, VariantType::DOUBLE,
+          0}});
 #endif
+  }
+
+  Variant call_method(const std::string &name, const VariantMap &) {
+    if (name == "get_force") {
+      return m_lbboundary->get_force();
+    }
   }
 
   const std::string name() const override { return "LBBoundaries:LBBoundary"; }

--- a/testsuite/python/CMakeLists.txt
+++ b/testsuite/python/CMakeLists.txt
@@ -17,6 +17,7 @@ set(py_tests  bondedInteractions.py
               rotational_inertia.py
               lbgpu_remove_total_momentum.py
               tabulated.py
+              lb_stokes_sphere_gpu.py
 )
 if(PY_H5PY)
   set(py_tests ${py_tests} h5md.py)

--- a/testsuite/python/lb_stokes_sphere_gpu.py
+++ b/testsuite/python/lb_stokes_sphere_gpu.py
@@ -1,0 +1,88 @@
+### Measuring the force on a single sphere immersed in a fluid with
+### fixed velocity boundary conditions created by two 
+### walls at finite distance.
+### The force is compared to th analytical result F=6 pi eta r v
+### i.e. the stokes force on the particles.
+
+
+# We create a box of size box_width x box_width x box_length and 
+# place an object in the center. We measure the drag force 
+# in z direction. We create walls in the xz and yz plane at the box 
+# boundaries, where the velocity is fixed to $v. 
+#
+from espressomd import System, lb, lbboundaries, shapes, has_features
+import unittest as ut
+import numpy as np
+import sys
+
+@ut.skipIf(not has_features(["LB_GPU", "LB_BOUNDARIES_GPU"]),
+           "Features not available, skipping test!")
+class Stokes(ut.TestCase):
+
+    es = System()	
+
+    def test_stokes(self):
+        # System setup
+        #system = System()
+        system=self.es
+        agrid = 1
+        radius = 5.5
+        box_width = 64
+        real_width = box_width+2*agrid
+        box_length = 64
+        system.box_l = [real_width, real_width, box_length]
+        system.time_step = 0.2
+        system.cell_system.skin = 0.4
+
+        # The temperature is zero.
+        system.thermostat.set_lb(kT=0)
+
+        # LB Parameters
+        v = [0,0,0.01] # The boundary slip 
+        kinematic_visc = 1.0
+
+        # Invoke LB fluid
+        lbf = lb.LBFluid_GPU(visc=kinematic_visc, dens=1, agrid=agrid, tau=system.time_step, fric=1)
+        system.actors.add(lbf)
+
+        # Setup walls
+        walls = [None] * 4
+        walls[0] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[-1,0,0], 
+                                           dist = -(1+box_width)), velocity=v)
+        walls[1] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[1,0,0], dist = 1),
+                                         velocity=v)
+        walls[2] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[0,-1,0], 
+                                           dist = -(1+box_width)), velocity=v)
+        walls[3] = lbboundaries.LBBoundary(shape=shapes.Wall(normal=[0,1,0], dist = 1),
+                                         velocity=v)
+
+        for wall in walls:
+            system.lbboundaries.add(wall)
+
+        # setup sphere without slip in the middle
+        sphere = lbboundaries.LBBoundary(shape=shapes.Sphere(radius=radius,
+                                     center = [real_width/2] * 2 + [box_length/2],
+                                     direction = 1))
+
+        system.lbboundaries.add(sphere)
+
+        def size(vector):
+            tmp = 0
+            for k in vector:
+                tmp+=k*k
+            return np.sqrt(tmp)
+
+        system.integrator.run(4000)
+
+        print("\nIntegration finished.")
+
+        # get force that is exerted on the sphere
+        force = sphere.get_force()
+        print("Measured force: f=%f" %size(force))
+        stokes_force = 6*np.pi*kinematic_visc*radius*size(v)
+        print("Stokes' Law says: f=%f" %stokes_force)
+        self.assertTrue(abs(1.0 - size(force)/stokes_force) <0.06)
+
+if __name__ == "__main__":
+    ut.main()
+


### PR DESCRIPTION
* partial fix for lbboundaries force interface

* lbboundaries: Bind get_force in python if.

* lbboundaries: Fix type for float params

* Added lb_stokes_sphere testcase.

* testsuite: Feature check for lb stokes tc.

* test_suite: Shortened mass-and-rinertia_pp test

* Revert "test_suite: Shortened mass-and-rinertia_pp test"

This reverts commit 9130d2b145ecc0434823e9340cf9e60f85652acc.

* testsuite: Remove lb stokes CPU test. Takes too long.

* testsuite: Readded lb stokes gpu file.

* testsuite: Better error measure for lb stokes sphere.

Fixes #

Description of changes:
 - 


PR Checklist
------------
 - [ ] Tests?
   - [ ] Interface
   - [ ] Core 
 - [ ] Docs?
